### PR TITLE
added backuppc_ssh_key_bits option to configure ssh key length

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Role Variables
 ### Role var
 
 - `backuppc_server_name`: fqdn of the backup server
+- `backuppc_ssh_key_bits`: set length of ssh key pair (optional, default 2048 by Ansible)
 - `backkuppc_fetch_ssh_key`: copy backkupc ssh key from server (boolean)
 - `backuppc_local_fetch_dir`: local dir where you fetch backuppc SSH public key
 - `backuppc_hosts`: clients list to backup (see below)

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,4 +17,5 @@
   user: >
     name=backuppc
     generate_ssh_key=yes
+    ssh_key_bits={{ backuppc_ssh_key_bits | default (omit) }}
     ssh_key_comment=backuppc@{{ backuppc_server_name }}


### PR DESCRIPTION
Hello HanXHX,

here an option to configure the ssh key length. It's optional so it should not break existing installations.

Best regards

Jard
