### PR TITLE
added options to configure also hosts (group/user, SSH auth, sudo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Role Variables
 - `backuppc_ssh_key_bits`: set length of ssh key pair (optional, default 2048 by Ansible)
 - `backuppc_fetch_ssh_key`: copy backkupc ssh key from server (boolean)
 - `backuppc_local_fetch_dir`: local dir where you fetch backuppc SSH public key
+- `backuppc_hosts_configure`: add group/user, place SSH public key and setup sudo rule on backuppc_hosts (optional)
+- `backuppc_hosts_gid`: GID of backuppc group on hosts (optional, not backuppc server)
+- `backuppc_hosts_uid`: UID of backuppc user on hosts (optional, not backuppc server)
+- `backuppc_hosts_ssh_keyotions`: global key options for SSH key in authorized_keys file (optional, useable to restrict from or command)
 - `backuppc_hosts`: clients list to backup (see below)
 
 ### Client vars
@@ -34,6 +38,9 @@ Each client configuration override global configuration.
 - `state`: (O) absent or present (default)
 - `include_files:`: (O) default files (directories) list to backup.
 - `exclude_files:`: (O) default files (directories) list to exclude in backup
+- `gid`: (O) GID of backuppc group on this host (overrides backuppc_hosts_gid)
+- `uid`: (O) UID of backuppc user on this host (overrides backuppc_hosts_uid)
+- `ssh_keyoptions`: (O) host specific option for SSH key in authorized_keys file (overrides backuppc_hosts_ssh_keyotions)
 - `more`: (O) hash with specific key/value (usefull for custom directives)
 
 (O): Optional (M): Mandatory

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 backuppc_server_name: "{{ ansible_hostname }}"
 backuppc_fetch_ssh_key: false
 backuppc_local_fetch_dir: "./fetch"
+backuppc_hosts_configure: false
 backuppc_hosts: []
 
 #

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -20,3 +20,46 @@
 
 - name: DEBUG | SSH pub key
   debug: var=cat.stdout
+
+- block:
+  - name: GROUP | Create backuppc group
+    group:
+      name: backuppc
+      gid: "{{ item.gid if item.gid is defined else backuppc_hosts_gid | default (omit) }}"
+      state: "{{ item.state | default (present) }}"
+    delegate_to: "{{ item.hostname }}"
+    with_items: "{{ backuppc_hosts }}"
+
+  - name: USER | Create backkupc user
+    user:
+      name: backuppc
+      uid: "{{ item.uid if item.uid is defined else backuppc_hosts_uid | default (omit) }}"
+      groups: backuppc
+      shell: '/bin/sh'
+      state: "{{ item.state | default (present) }}"
+      comment: 'BackupPC user'
+    delegate_to: "{{ item.hostname }}"
+    with_items: "{{ backuppc_hosts }}"
+
+  - name: AUTHORIZED_KEY | Place public SSH key
+    authorized_key:
+      user: backuppc
+      key: "{{ lookup('file', '{{ backuppc_local_fetch_dir }}/id_rsa.pub') }}"
+      key_options: "{{ item.ssh_keyoptions if item.ssh_keyoptions is defined else backuppc_hosts_ssh_keyotions | default (omit) }}"
+      state: "{{ item.state | default (present) }}"
+    delegate_to: "{{ item.hostname }}"
+    with_items: "{{ backuppc_hosts }}"
+    when: item.hostname != "localhost"
+
+  - name: LINEINFILE | Grant sudo privileges
+    lineinfile:
+      dest: /etc/sudoers.d/backuppc
+      create: yes
+      line: 'backuppc  ALL=NOPASSWD: /usr/bin/rsync --server --sender *'
+      regexp: '^backuppc'
+      state: "{{ item.state | default (present) }}"
+      validate: 'visudo -cf %s'
+    delegate_to: "{{ item.hostname }}"
+    with_items: "{{ backuppc_hosts }}"
+
+  when: ansible_hostname != "{{ backuppc_server_name }}" and backuppc_hosts_configure


### PR DESCRIPTION
Hello @HanXHX,

here comes another one. Hope i'm not stressing you :).
This PR will enable the user to also use the module to configure the hosts added in backuppc_hosts. Means the module will create a group+user, place the before fetched SSH key and place a sudo rule.

What do you think?

Best
Jard

PS: I'm planning also to add options to globally configure 
$Conf{BackupFilesOnly} = {};
$Conf{BackupFilesExclude} = {};
This will come in another PR.
