### PR TITLE
Change name of configuration task

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,7 +9,7 @@
     mode=0640
   notify: restart backuppc
 
-- name: TEMPLATE | Put config to BackupPC server
+- name: TEMPLATE | Put host specific config on BackupPC server
   template: >
     src=etc/backuppc/_host_config.pl.j2
     dest='/etc/backuppc/{{ item.hostname }}.pl'


### PR DESCRIPTION
The original text didn't clearly indicate that the configuration being moved was for a host
so it seemed out of place compared to the entry above it which talked about global config